### PR TITLE
Add NODE_ENV to build:lib command to avoid hardcoded paths in compiled library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "clean": "rm -rf dist lib && mkdir dist lib",
     "prebuild": "npm run clean",
-    "build:lib": "babel src --out-dir lib",
+    "build:lib": "NODE_ENV=production babel src --out-dir lib",
     "build:umd": "NODE_ENV=production webpack src/index.js dist/react-skroll.js",
     "build:umd:min": "NODE_ENV=production TARGET=minify webpack src/index.js dist/react-skroll.min.js",
     "build": "npm run build:lib && npm run build:umd && npm run build:umd:min",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-skroll",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Reactive Scrolling",
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Closes #1.