### PR TITLE
Fixed observe TypeError

### DIFF
--- a/src/Scroller.js
+++ b/src/Scroller.js
@@ -58,9 +58,11 @@ export default class Scroller extends Component {
         })
       }
     })
-
-    this.resizeObserver.observe(this.target)
-
+    
+    if(this.target){
+      this.resizeObserver.observe(this.target)
+    }
+    
     this.props.scrollRef(this.connection)
   }
 


### PR DESCRIPTION
ypeError: Failed to execute 'observe' on 'ResizeObserver': parameter 1 is not of type 'Element' happend when using with React-Router Link component.